### PR TITLE
Reduce dlcs_count on DLC-enabled servers to fix BufferExhaustedError

### DIFF
--- a/dayzquery.py
+++ b/dayzquery.py
@@ -63,11 +63,11 @@ class DayzRules(metaclass=DataclsMeta):
 
 
 def dayz_rules(address, timeout=DEFAULT_TIMEOUT, encoding=DEFAULT_ENCODING):
-    rules_resp = a2s.rules(address, timeout, encoding)
+    rules_resp = a2s.rules(address, encoding=None)
     return dayz_rules_decode(rules_resp, encoding)
 
 async def dayz_arules(address, timeout=DEFAULT_TIMEOUT, encoding=DEFAULT_ENCODING):
-    rules_resp = await a2s.arules(address, timeout, encoding)
+    rules_resp = await a2s.arules(address, encoding=None)
     return dayz_rules_decode(rules_resp, encoding)
 
 

--- a/dayzquery.py
+++ b/dayzquery.py
@@ -94,6 +94,8 @@ def dayz_rules_decode(rules_resp, encoding=DEFAULT_ENCODING):
     result.unknown_3 = reader.read_uint8()
 
     result.dlcs = []
+    if (result.dlcs_count > 0):
+        result.dlcs_count = result.dlcs_count - 1
     for i in range(result.dlcs_count):
         result.dlcs.append(reader.read_uint32())
 


### PR DESCRIPTION
Reducing/normalizing the integer value of dlcs_count allows the parser to decode the A2S_RULES response from these servers. This was previously not necessary, since no DLC existed for servers. This change is compatible with both legacy and DLC-enabled servers.