### PR TITLE
feat: enumerated DLCs

### DIFF
--- a/dayzquery.py
+++ b/dayzquery.py
@@ -12,10 +12,12 @@ https://community.bistudio.com/wiki/Arma_3:_ServerBrowserProtocol3
 I do not understand their meaning at the time of writing as I have never played DayZ.
 """
 
+
 @dataclass
 class DLCDetails:
     flag: int
     appid: int
+
 
 class DLC(DLCDetails, Enum):
     """Flags to indicate which DLCs are present in the response,
@@ -24,6 +26,7 @@ class DLC(DLCDetails, Enum):
     VANILLA = (0, 221100)
     FROSTLINE = (2, 2968040)
     BADLANDS = (3, 3816030)
+
 
 @dataclass
 class DayzMod:
@@ -38,6 +41,7 @@ class DayzMod:
 
     """Mod name"""
     name: str
+
 
 @dataclass
 class DayzRules:
@@ -76,10 +80,10 @@ class DayzRules:
     time_left: int
 
 
-
 def dayz_rules(address, timeout=DEFAULT_TIMEOUT, encoding=DEFAULT_ENCODING):
     rules_resp = a2s.rules(address, timeout, encoding=None)
     return dayz_rules_decode(rules_resp, encoding)
+
 
 async def dayz_arules(address, timeout=DEFAULT_TIMEOUT, encoding=DEFAULT_ENCODING):
     rules_resp = await a2s.arules(address, timeout, encoding=None)


### PR DESCRIPTION
This is a pre-emptive change that looks ahead to the release of https://store.steampowered.com/app/3816030/DayZ_Badlands/, slated for 2026. Given the current incrementing scheme, it seems reasonable to assume that this DLC will follow the same logic and be given the flag `3`, but this is speculation and would have to be tested on real servers.

Separately, this commit tries to add more specificity to the DLC flags by structuring them as Enums with a corresponding appid. Since DLC are hardcoded to a specific appid, this value is invariate.

Providing the appid in the response could aid users of the module who want to display additional information, and also hopefully structures the enum better so that values like `0` and `2` are not simply a magic number, but tied to some real-world UID.

I don't think it's possible for a server to have multiple DLCs at a given time, since they are unique game modes that are mutually exclusive.

Also, I have reason to believe that the missing enumeration `1` for the DLC flags corresponds to the Livonia DLC. This DLC was grandfathered into the main game on 2024-05-27 following the 1.25 update. So there was a narrow window of time when some servers might have returned a `1` here, but it's not possible anymore. Whether this flag should be included in the enums for historical purposes, I am not sure, but it seems safe to say that it's not possible for a server to ever return a `1` at this point.

